### PR TITLE
コミット漏れの修正

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,6 @@
 /[Bb]uilds/
 /[Ll]ogs/
 /[Mm]emoryCaptures/
-Assets/Voiceer/VoiceResources*
 
 # Never ignore Asset meta data
 !/[Aa]ssets/**/*.meta

--- a/Assets/Plugins.meta
+++ b/Assets/Plugins.meta
@@ -1,8 +1,0 @@
-fileFormatVersion: 2
-guid: 7562374ba7950104b8082d1e827ce31a
-folderAsset: yes
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/Assets/Plugins/Editor.meta
+++ b/Assets/Plugins/Editor.meta
@@ -1,8 +1,0 @@
-fileFormatVersion: 2
-guid: 89c246c67fc67f3429241fc3be572006
-folderAsset: yes
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/Assets/Voiceer/VoiceResources/MusubimeYuiVoices/MusubimeYui.asset
+++ b/Assets/Voiceer/VoiceResources/MusubimeYuiVoices/MusubimeYui.asset
@@ -1,0 +1,57 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 8
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 66c234d987ce84d498c0cdd3b7a2d4e7, type: 3}
+  m_Name: MusubimeYui
+  m_EditorClassIdentifier: 
+  voiceSetList:
+  - trigger: 0
+    sound:
+      voiceClips:
+      - {fileID: 8300000, guid: 3f9f3222ceba6df41888739ad936344d, type: 3}
+      - {fileID: 8300000, guid: 59f123fa6b293724db0e9a52d5915258, type: 3}
+      - {fileID: 8300000, guid: e26faa569f044f84288c8939d8d4148d, type: 3}
+      - {fileID: 8300000, guid: 44bbbc2603dd44041ad1ff9d934d8d16, type: 3}
+  - trigger: 1
+    sound:
+      voiceClips:
+      - {fileID: 8300000, guid: 93a4561820fcda74793ad675948b2e09, type: 3}
+  - trigger: 2
+    sound:
+      voiceClips:
+      - {fileID: 8300000, guid: 2c4a17fa0acc8df48a6d92bb752a0b51, type: 3}
+  - trigger: 3
+    sound:
+      voiceClips:
+      - {fileID: 8300000, guid: 0963ff08eca225642a4a84594e758080, type: 3}
+  - trigger: 4
+    sound:
+      voiceClips:
+      - {fileID: 8300000, guid: 42e50b4c32a6f2e48a74a40054265ac2, type: 3}
+  - trigger: 5
+    sound:
+      voiceClips:
+      - {fileID: 8300000, guid: 52a4a36dfbc5f844c8bb3467fd716483, type: 3}
+  - trigger: 6
+    sound:
+      voiceClips:
+      - {fileID: 8300000, guid: 1d82255593eee3249ac633968d130a6a, type: 3}
+  - trigger: 7
+    sound:
+      voiceClips:
+      - {fileID: 8300000, guid: e7225d770233c9446a0d7a0bbd835d0d, type: 3}
+  - trigger: 8
+    sound:
+      voiceClips:
+      - {fileID: 8300000, guid: 3c9036e50857a0841b8d7e5559eea263, type: 3}
+  metaData:
+    memo: "\u7D50\u76EE\u30E6\u30A4\u3061\u3083\u3093\u306EFanbox\u9650\u5B9A\u30D5\u30EB\u30DC\u30A4\u30B9\u306A\u30DC\u30A4\u30B9Preset\u3067\u3059\u3002"
+    url: https://twitter.com/musubimeyui

--- a/Assets/Voiceer/VoiceResources/MusubimeYuiVoices/MusubimeYui.asset.meta
+++ b/Assets/Voiceer/VoiceResources/MusubimeYuiVoices/MusubimeYui.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: a794767d3d824b64bafbbd20a7703076
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
# 概要

リポジトリをcloneすると、配布されている`.unitypackage`に含まれている`MusubimeYuiVoice.asset`がcommitされていませんでした。`VoicePresetSelector`の参照先も`MusubimeYuiVoice.asset`であることを確認したので、意図しないコミット漏れであると判断し修正しました。

# 確認して欲しいこと

上記の原因は`.gitiginore` に`VoiceResources`が設定されていることでした。
しかし、`VoiceResources`以下には`MusubimeYuiVoices`が含まれているため、これは誤りではないでしょうか(`MusubimeYuiVoice.asset`を除く`MusubimeYuiVoices`は、`.gitiginore` に`VoiceResources`が追加される前のcommitで追加されています)。

また、併せて使用されていない`Plugins/Editor`フォルダを削除しました。


