### PR TITLE
ボリューム変更機能の追加

### DIFF
--- a/Assets/Voiceer/Editor/Scripts/VoicePresetSelectorEditor.cs
+++ b/Assets/Voiceer/Editor/Scripts/VoicePresetSelectorEditor.cs
@@ -11,6 +11,18 @@ namespace Voiceer
         private const string TitleString = "Voiceer - Voice Preset Selector";
 
         private static VoicePresetSelector _selector = null;
+        private static readonly string IsVolumeControlEnabledKey = "VoiceerIsVolumeControlEnabled";
+        private static readonly string VolumeKey = "VoiceerVolume";
+        public static bool isVolumeControlEnabled
+        {
+            get => EditorPrefs.GetBool(IsVolumeControlEnabledKey, false);
+            private set => EditorPrefs.SetBool(IsVolumeControlEnabledKey, value);
+        }
+        public static float volume
+        {
+            get => EditorPrefs.GetFloat(VolumeKey, 0f);
+            private set => EditorPrefs.SetFloat(VolumeKey, value);
+        }
 
         [MenuItem("Window/Voiceer/Voice Preset Selector")]
         private static void Open()
@@ -38,6 +50,20 @@ namespace Voiceer
                 // エディタを最新の状態にする
                 AssetDatabase.Refresh();
             }
+
+            EditorGUILayout.BeginHorizontal();
+            EditorGUILayout.LabelField("ボリューム調整機能を利用(Experimental)");
+            isVolumeControlEnabled = EditorGUILayout.Toggle(isVolumeControlEnabled);
+            EditorGUILayout.EndHorizontal();
+            EditorGUILayout.BeginHorizontal();
+            EditorGUI.BeginDisabledGroup(!isVolumeControlEnabled);
+            const string label = "ボリューム(dB)";
+            float labelWidth = EditorStyles.label.CalcSize(new GUIContent(label)).x;
+            EditorGUILayout.LabelField(label, GUILayout.MinWidth(labelWidth), GUILayout.MaxWidth(labelWidth));
+            volume = EditorGUILayout.Slider(volume, -40f, 40f);
+            EditorGUI.EndDisabledGroup();
+            EditorGUILayout.EndHorizontal();
+
             VoiceerEditorUtility.Hr(position.width);
             
             if (_selector.CurrentVoicePreset == null)


### PR DESCRIPTION
# 概要
ボリューム変更機能を追加しました

<img width="439" alt="スクリーンショット 2020-01-18 12 32 03" src="https://user-images.githubusercontent.com/45461765/72658018-8e435b00-39ee-11ea-8d08-78b3179f1c6b.png">

## 詳細
現状版ではボリューム変更できなかったので、変更機能を追加しました。
従来のUnityEditor.AudioUtilを使う方法ではボリューム変更できなかったため、一時的にシーンにGameObjectを追加する方法で音声再生をしています。
そのため、不具合発生の可能性も考慮してラベルに(Experimental)と表記し、従来の方法と選択可能にしました。
Unity 2019.3.0f5で動作確認しました。

## 確認して欲しいこと
・再生方法の変更に問題がないか
・設定をEditorPrefsに記録しているが問題ないか
・ボリューム設定をPreset Selectorウィンドウに表示しているが問題ないか
・Experimentalと表記して問題ないか