### PR TITLE
テスト実行・完了時の音声再生を追加

### DIFF
--- a/Assets/Voiceer/Editor/Scripts/ScriptableObject/VoicePreset.cs
+++ b/Assets/Voiceer/Editor/Scripts/ScriptableObject/VoicePreset.cs
@@ -16,6 +16,10 @@ namespace Voiceer
         OnPostProcessBuildFailed,
         OnSave,
         OnBuildTargetChanged,
+        OnTestRunStarted,
+        OnTestRunSuccessfully,
+        OnTestRunFailed,
+        OnTestError
     }
 
     [Serializable]

--- a/Assets/Voiceer/Editor/Scripts/TestHook.cs
+++ b/Assets/Voiceer/Editor/Scripts/TestHook.cs
@@ -1,0 +1,58 @@
+#if UNITY_2019_2_OR_NEWER
+using UnityEditor;
+using UnityEditor.TestTools.TestRunner.Api;
+using UnityEngine;
+
+namespace Voiceer
+{
+    /// <summary>
+    /// ユニットテストの実行・完了イベントをフックして音声を再生します
+    /// Required: Unity 2019.2 + Test Framework 1.1 or newer
+    /// see: https://docs.unity3d.com/Packages/com.unity.test-framework@1.1/manual/reference-icallbacks.html
+    /// </summary>
+    public class TestHook
+    {
+        [InitializeOnLoadMethod]
+        private static void SetupListeners()
+        {
+            var api = ScriptableObject.CreateInstance<TestRunnerApi>();
+            api.RegisterCallbacks(new TestCallbacks());
+        }
+
+        private class TestCallbacks : IErrorCallbacks
+        {
+            public void RunStarted(ITestAdaptor testsToRun)
+            {
+                SoundPlayer.PlaySound(Hook.OnTestRunStarted);
+            }
+
+            public void RunFinished(ITestResultAdaptor result)
+            {
+                if (result.FailCount == 0)
+                {
+                    SoundPlayer.PlaySound(Hook.OnTestRunSuccessfully);
+                }
+                else
+                {
+                    SoundPlayer.PlaySound(Hook.OnTestRunFailed);
+                }
+            }
+
+            public void TestStarted(ITestAdaptor test)
+            {
+                // テストノード単位の開始契機なので音声再生はしない
+            }
+
+            public void TestFinished(ITestResultAdaptor result)
+            {
+                // テストノード単位の終了契機なので音声再生はしない
+            }
+
+            public void OnError(string message)
+            {
+                SoundPlayer.PlaySound(Hook.OnTestError);
+            }
+        }
+    }
+}
+#endif

--- a/Assets/Voiceer/Editor/Scripts/TestHook.cs.meta
+++ b/Assets/Voiceer/Editor/Scripts/TestHook.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: ee29642ac636416792e4fe5e4815414d
+timeCreated: 1579332131

--- a/Assets/Voiceer/Editor/Scripts/VoiceerEditorUtility.cs
+++ b/Assets/Voiceer/Editor/Scripts/VoiceerEditorUtility.cs
@@ -143,6 +143,14 @@ namespace Voiceer
                     return "プロジェクトをセーブした時";
                 case Hook.OnBuildTargetChanged:
                     return "ビルドターゲットを変更した時";
+                case Hook.OnTestRunStarted:
+                    return "ユニットテストを実行開始した時（Unity 2019.2以降で有効）";
+                case Hook.OnTestRunSuccessfully:
+                    return "ユニットテストが成功した時（Unity 2019.2以降で有効）";
+                case Hook.OnTestRunFailed:
+                    return "ユニットテストが失敗した時（Unity 2019.2以降で有効）";
+                case Hook.OnTestError:
+                    return "ユニットテスト実行時エラーがあった時（Unity 2019.2以降で有効）";
                 default:
                     //上記で未定義なTriggerはそのまま出力
                     return trigger.ToString();

--- a/Assets/Voiceer/Tests.meta
+++ b/Assets/Voiceer/Tests.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 089fad7c26d3b4a629b36b46900f05ac
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Voiceer/Tests/EditMode.meta
+++ b/Assets/Voiceer/Tests/EditMode.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: c85dcb8f228294dba8ea7fcdcf60f8e3
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Voiceer/Tests/EditMode/SampleTest.cs
+++ b/Assets/Voiceer/Tests/EditMode/SampleTest.cs
@@ -1,0 +1,19 @@
+using NUnit.Framework;
+
+namespace Voiceer
+{
+    public class SampleTest
+    {
+        [Test]
+        public void TestPassSample()
+        {
+            Assert.That(true, Is.True);
+        }
+
+        [Test]
+        public void TestFailSample()
+        {
+            Assert.That(false, Is.True);
+        }
+    }
+}

--- a/Assets/Voiceer/Tests/EditMode/SampleTest.cs.meta
+++ b/Assets/Voiceer/Tests/EditMode/SampleTest.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 899c9d74fd52d49379c005ccfc775975
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Voiceer/Tests/EditMode/Voiceer.EditModeTests.asmdef
+++ b/Assets/Voiceer/Tests/EditMode/Voiceer.EditModeTests.asmdef
@@ -1,0 +1,16 @@
+{
+    "name": "Voiceer.EditModeTests",
+    "references": [],
+    "optionalUnityReferences": [
+        "TestAssemblies"
+    ],
+    "includePlatforms": [
+        "Editor"
+    ],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": false,
+    "precompiledReferences": [],
+    "autoReferenced": true,
+    "defineConstraints": []
+}

--- a/Assets/Voiceer/Tests/EditMode/Voiceer.EditModeTests.asmdef.meta
+++ b/Assets/Voiceer/Tests/EditMode/Voiceer.EditModeTests.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 2afbca8bad8a34ac58723c46d6e0d6a4
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
### 変更内容
Unity 2019.2以降、かつ、Unity Test Framework 1.1.0以降がインポートされているとき、以下のイベントをフックして音声再生を追加
- ユニットテスト実行開始
- ユニットテスト成功（全件成功）
- ユニットテスト失敗（1件でも失敗）
- ユニットテスト実行時エラー

### 補足
- "Add sample tests"のコミットは、不要であればrevertしてください
- Unity 2019.2未満であっても、Voice Presetには上記項目を含んだものを生成できます
- デフォルトのVoice Presetは変更していません