### PR TITLE
UnityPackageファイル作成のGitHub Actionsによる自動化

### DIFF
--- a/.github/workflows/UnityPackageCreate.yaml
+++ b/.github/workflows/UnityPackageCreate.yaml
@@ -1,0 +1,66 @@
+# MIT License
+# Copyright (c) 2020 pCYSl5EDgo
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+name: UnityPackageCreate
+
+on:
+  push:
+    tags:
+    - '**'
+
+jobs:
+  Create:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        unity-version: 
+        - 2018.4.15f1
+    steps:
+    - uses: actions/checkout@v2
+    - run: |
+        echo "Assets/Voiceer.meta" > metaList
+        find Assets/Voiceer/ -name \*.meta >> metaList
+
+    - uses: pCYSl5EDgo/create-unitypackage@master
+      with:
+        package-path: Voiceer+sample.unitypackage
+        include-files: metaList
+    
+    - name: Create Release
+      id: create_release
+      uses: actions/create-release@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        tag_name: ${{ github.ref }}
+        release_name: ${{ github.ref }}
+        draft: false
+        prerelease: false
+    
+    - name: Upload Release Asset
+      uses: actions/upload-release-asset@master
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ steps.create_release.outputs.upload_url }}
+        asset_path: Voiceer+sample.unitypackage
+        asset_name: Voiceer+sample.unitypackage
+        asset_content_type: application/gzip

--- a/.github/workflows/UnityPackageCreate.yaml
+++ b/.github/workflows/UnityPackageCreate.yaml
@@ -29,10 +29,6 @@ on:
 jobs:
   Create:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        unity-version: 
-        - 2018.4.15f1
     steps:
     - uses: actions/checkout@v2
     - run: |


### PR DESCRIPTION
# 概要
tagがpushされた時に自動的にAssets/Voiceer以下のファイルをunitypackageにまとめます。
また、tagを元にしてGitHub Releasesに新規Releaseを作成し、Voiceer+sample.unitypackageを格納します。

手動でunitypackageを作り、GitHubでCreate Releaseしてからアップロードする手間からねぎぽよしさんが解放されます。