### PR TITLE
2020.1以降対応

### DIFF
--- a/Assets/Voiceer/Editor/Scripts/SoundPlayer.cs
+++ b/Assets/Voiceer/Editor/Scripts/SoundPlayer.cs
@@ -31,7 +31,11 @@ namespace Voiceer
             
             var method = audioUtilClass.GetMethod
             (
+#if UNITY_2020_1_OR_NEWER
+                "PlayPreviewClip",
+#else
                 "PlayClip",
+#endif
                 BindingFlags.Static | BindingFlags.Public,
                 null,
 #if UNITY_2019_2_OR_NEWER


### PR DESCRIPTION
Unity 2020から、"PlayClip"が"PlayPreviewClip"に変更されましたので、
それを対応しました。

参考：
https://github.com/Unity-Technologies/UnityCsReference/commit/3417c31e48410974acf40a2a461b31f9a49051ba